### PR TITLE
Remove API: Try.throw

### DIFF
--- a/src/Try.jl
+++ b/src/Try.jl
@@ -29,8 +29,6 @@ const ConcreteErr{E} = ConcreteResult{Union{},E}
 
 const Result{T,E} = Union{ConcreteResult{<:T,<:E},DynamicResult{<:T,<:E}}
 
-function throw end
-
 function unwrap end
 function unwrap_err end
 

--- a/src/core.jl
+++ b/src/core.jl
@@ -5,14 +5,14 @@ Try.Err{E}(value) where {E<:Exception} = Try.Err{E}(value, maybe_backtrace())
 
 Try.unwrap(result::ConcreteResult) = Try.unwrap(result.value)
 Try.unwrap(ok::Ok) = ok.value
-Try.unwrap(err::Err) = Try.throw(err)
+Try.unwrap(err::Err) = _throw(err)
 
 Try.unwrap_err(result::ConcreteResult) = Try.unwrap_err(result.value)
 Try.unwrap_err(ok::Ok) = throw(Try.IsOkError(ok))
 Try.unwrap_err(err::Err) = err.value
 
-Try.throw(err::ConcreteErr) = Try.throw(err.value)
-function Try.throw(err::Err)
+_throw(err::ConcreteErr) = _throw(err.value)
+function _throw(err::Err)
     if err.backtrace === nothing
         throw(err.value)
     else


### PR DESCRIPTION
It's essentially equivalent to `Try.unwrap`. Let's minimize API for now.